### PR TITLE
Change CITATION.bib to CITATION.cff

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,8 +1,0 @@
-@misc{JSOTemplate.jl,
-	author  = {Abel Soares Siqueira <abel.s.siqueira@gmail.com> and contributors},
-	title   = {JSOTemplate.jl},
-	url     = {https://github.com/JuliaSmoothOptimizers/JSOTemplate.jl},
-	version = {v0.1.0},
-	year    = {2021},
-	month   = {9}
-}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,10 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+  - family-names: Template
+    given-names: JSO
+    orcid: https://orcid.org/0123-4567-89AB-CDEF
+title: "JSO Template"
+version: 2.0.4
+doi: 10.5281/zenodo.1234
+date-released: 2021-10-04


### PR DESCRIPTION
https://citation-file-format.github.io/\#/what-is-a-citation-cff-file

CITATION.cff should substitute both CITATION.bib and zenodo.json, so we can close two issues.

Closes #1, #2