### PR TITLE
Fix typo in `autodocs`

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -13,5 +13,5 @@ Pages = ["reference.md"]
 ```
 ​
 ```@autodocs
-Modules = [NLPModels]
+Modules = [JSOTemplate]
 ```


### PR DESCRIPTION
This should fix the error in the documentation deployement.